### PR TITLE
Bump hsqldb to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,8 @@
       <artifactId>hsqldb</artifactId>
       <!-- Required vulnerability patch in 2.7.1 is not available -->
       <!-- See: https://github.com/advisories/GHSA-77xx-rxvh-q682 -->
-      <version>2.5.2</version>
+      <version>2.7.0</version>
+      <classifier>jdk8</classifier>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
Replaces #63 and #64 

Turns out the jdk8 version of the hsqldb jar is published to Maven Central: https://sourceforge.net/p/hsqldb/discussion/73673/thread/aa858ebf4b/

All we need is the `jdk8` classifier.
